### PR TITLE
Fix/cache problem

### DIFF
--- a/src/BeagleUIView.ts
+++ b/src/BeagleUIView.ts
@@ -204,7 +204,7 @@ const createBeagleView = <Schema>({
         errorComponent: params.errorComponent,
         loadingComponent: params.loadingComponent,
         headers: params.headers,
-        strategy,
+        strategy: params.strategy || strategy,
         method: params.method,
         shouldShowError: params.shouldShowError,
         shouldShowLoading: params.shouldShowLoading,

--- a/src/BeagleUIView.ts
+++ b/src/BeagleUIView.ts
@@ -51,6 +51,7 @@ const createBeagleView = <Schema>({
   analytics,
   customStorage,
   useBeagleHeaders,
+  strategy,
 }: BeagleConfig<Schema>, initialRoute: string): BeagleView<Schema> => {
   let currentUITree: IdentifiableBeagleUIElement<Schema>
   const listeners: Array<Listener<Schema>> = []
@@ -203,6 +204,7 @@ const createBeagleView = <Schema>({
         errorComponent: params.errorComponent,
         loadingComponent: params.loadingComponent,
         headers: params.headers,
+        strategy,
         method: params.method,
         shouldShowError: params.shouldShowError,
         shouldShowLoading: params.shouldShowLoading,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Send selected strategy to fetch function, so the strategy is respected while handling the fetch data. 
The problem was that even the user changing the default strategy, the loadUITree didn't received that information so it always keept the default strategy.

**- How I did it**
Add a new argument when calling loadUITree

**- How to verify it**
I used the playground and the poc angular/show-default-components to test. 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix cache strategy.