### PR TITLE
forces jest to run tests with esnext instead of es5

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -83,7 +83,8 @@ module.exports = {
   // A set of global variables that need to be available in all test environments
   globals: {
     'ts-jest': {
-      diagnostics: false
+      diagnostics: false,
+      tsConfig: 'tsconfig.spec.json',
     },
     window: true
   },

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
A test was failing because of es5. I fixed it.

**- How I did it**
I made it so jest uses esnext to run the tests, like it was before adding support to es5. We should give a better look into it in the next major version.

**- How to verify it**
Run the tests

**- Description for the changelog**
Fixes tests
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
