### PR TITLE
Beagle Tree: fixes iteration index

### DIFF
--- a/src/beagle-tree/iteration.ts
+++ b/src/beagle-tree/iteration.ts
@@ -33,7 +33,7 @@ export function forEach<T extends BeagleUIElement>(tree: T, iteratee: Iteratee<T
   let index = 0
 
   function run(node: T) {
-    iteratee(node, ++index)
+    iteratee(node, index++)
     if (node.children) node.children.forEach(child => run(child as T))
   }
 
@@ -63,7 +63,7 @@ export function replaceEach<T extends BeagleUIElement>(
   let index = 0
 
   function run(node: BeagleUIElement) {
-    const newNode = iteratee(node as T, ++index)
+    const newNode = iteratee(node as T, index++)
     if (!newNode.children) return newNode
     for (let i = 0; i < newNode.children.length; i++) {
       newNode.children[i] = run(newNode.children[i])


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Indexes in a beagle tree iteration should start at 0, they were starting at 1.

**- How I did it**
Just placed `++` in the correct place.

**- How to verify it**

**- Description for the changelog**
Indexes in in a beagle tree iteration should start at 0, they were starting at 1.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
