### PR TITLE
fixing validation for external PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,21 +43,13 @@ jobs:
     - name: type-check for tests
       run: yarn check-test-types
 
-    - name: Jest Annotations & Coverage
-      if: ${{ github.repository_owner == 'ZupIT'}}
+    - name: test
+      run: yarn test
+
+    - name: test and comment
+      continue-on-error: true
       uses: mattallty/jest-github-action@v1.0.3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         test-command: "yarn test --maxWorkers=2"
-
-    - name: Jest Coverage
-      if: ${{ github.repository_owner != 'ZupIT'}}
-      uses: mattallty/jest-github-action@v1.0.3
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        test-command: "yarn test --maxWorkers=2"
-        coverage-comment: false
-
-


### PR DESCRIPTION
Analogous to https://github.com/ZupIT/beagle-web-react/pull/161

I tried everything I could. Unfortunately I could not make `mattallty/jest-github-action` run only if `secrets.GITHUB_TOKEN` exists. I also could not find a way to prevent `mattallty/jest-github-action` from posting comments only if `secrets.GITHUB_TOKEN` exists.

Since I don't see the point in re-implementing `mattallty/jest-github-action` just to prevent it from running for external PRs, I decided to run the tests twice:

- 1st time: tests are run using `yarn test`, if they fail, the job fails and PR can't be merged
- 2nd time: tests are re-run with `mattallty/jest-github-action` so it can make the comments it needs to. But, if it fails, the job won't fail and PR can still be merged.

It's not ideal, but it's the fastest solution for now. The ideal implementation would be to make this comment ourselves, without the need for `mattallty/jest-github-action`. Another solution would be to make a PR to `mattallty/jest-github-action` that implements our needs.
