### PR TITLE
Fixes the jsdocs for all functions in Tree

### DIFF
--- a/src/beagle-tree/index.ts
+++ b/src/beagle-tree/index.ts
@@ -14,12 +14,145 @@
  * limitations under the License.
  */
 
-import * as iteration from './iteration'
-import * as manipulation from './manipulation'
-import * as reading from './reading'
+import { forEach, iterator, replaceEach } from './iteration'
+import { addChild, clone, insertIntoTree, replaceInTree } from './manipulation'
+import { findByAttribute, findById, findByType, findParentByChildId, indexOf } from './reading'
 
 export default {
-  ...iteration,
-  ...manipulation,
-  ...reading,
+  /**
+   * Uses a depth first search algorithm to traverse the tree. The iteratee function will be run for
+   * each node (component). The iteratee function is triggered once a node is visited, i.e. the
+   * first node to run the function is the root node and not the deepest left-most node.
+   * 
+   * The children of a node must be called "children" and be an array.
+   * 
+   * @param tree the tree to traverse
+   * @param iteratee the function to call for each node of the tree
+   */
+  forEach,
+  /**
+   * Uses a depth first search algorithm to traverse the tree and exposes this functionality as an
+   * iterator. Each call to next() walks a step in the tree.
+   * 
+   * The children of a node must be called "children" and be an array.
+   * 
+   * @param tree the tree to traverse
+   * @returns the iterator to iterate over the nodes
+   */
+  iterator,
+  /**
+   * Does the same as forEach (depth-first-search), the difference is that the iteratee function
+   * expects a return value, which will be used to replace the current node in the tree. A value
+   * must be returned by the iteratee function, if you don't want to change the current node, just
+   * return the same node you received. If a node is replaced by another one, the tree will be
+   * updated and the next node to run the iteratee function will be the first child of the new node
+   * (if it has any children).
+   * 
+   * The children of a node must be called "children" and be an array.
+   * 
+   * @param tree the tree to traverse
+   * @param iteratee the function to call for each node of the tree. This function must return a
+   * node, which will be used to replace the current node of the tree.
+   * @returns the new tree
+   */
+  replaceEach,
+  /**
+   * Adds a child element to the target tree. If the mode is "append", the child will be added as
+   * the last element of the target's children. If "prepend", it will be added as the first child.
+   * 
+   * This function modifies `target`, it's not a pure function.
+   * 
+   * @param target the tree to be modified by receiving the new node `child`
+   * @param child the node to insert into the tree `target`
+   * @param mode the insertion strategy. Prepend (insert as first child), append (insert as last
+   * child) or replace (removes all children and inserts `child`).
+   */
+  addChild,
+  /**
+   * Deep-clones the tree passed as parameter.
+   * 
+   * @param tree the tree to be cloned
+   * @returns the clone of the tree
+   */
+  clone,
+  /**
+   * Combine two trees. This function inserts the tree `source` into the tree `target` at the node
+   * referred by `anchor`. To tell which position `source` should occupy in the array of children of
+   * `anchor`, you should use the last parameter `mode`.
+   * 
+   * If there's no node with id `anchor`, the tree will be left untouched.
+   * 
+   * This function modifies `target`, it's not a pure function.
+   * 
+   * @param target the tree to be modified by receiving the new branch `source`
+   * @param source the tree to be inserted into `target`
+   * @param anchor the id of the node to attach the new branch to
+   * @param mode the insertion strategy. Prepend (insert as first child of `anchor`), append (insert
+   * as last child of `anchor`) or replace (removes all children of `anchor` and inserts `child`).
+   */
+  insertIntoTree,
+  /**
+   * Just like `insertIntoTree`, `replaceInTree` combines two trees. But, instead of inserting the
+   * new branch as a child of the node referred by `anchor`, it completely replaces `anchor`, i.e.
+   * after this function runs, `anchor` doesn't exist in `target` anymore, it gets replaced by the
+   * tree `source`.
+   * 
+   * If there's no node with id `anchor` or if `anchor` is the root node, the tree will be left
+   * untouched.
+   * 
+   * This function modifies `target`, it's not a pure function.
+   * 
+   * @param target the tree to be modified by receiving the new branch `source`
+   * @param source the tree to be inserted into `target`
+   * @param anchor the id of the node to be replaced by the new branch `source`
+   */
+  replaceInTree,
+  /**
+   * Finds every node in a tree where the value of `attributeName` is `attributeValue`. When
+   * `attributeValue` is omitted, all nodes with a parameter called `attributeName` will be
+   * returned. If no node is found, an empty array is returned.
+   * 
+   * @param tree the tree where to search the nodes
+   * @param attributeName the attribute name to look for
+   * @param attributeValue optional. The value of `attributeName` to look for. If not specified,
+   * any value is accepted, i.e. a node, to be found, will only need to have a parameter
+   * `attributeName`, no matter the value of it.
+   * @returns an array with all nodes found
+   */
+  findByAttribute,
+  /**
+   * Finds a node by its id. If no node is found, null is returned.
+   * 
+   * @param tree the tree where to search the node
+   * @param id the id of the node to find
+   * @returns the node with the given id or null if `tree` has no node with id `id`.
+   */
+  findById,
+  /**
+   * Finds all nodes with a given type. The type of a node is defined by the property
+   * `_beagleComponent_`. If no node is found, an empty array is returned.
+   * 
+   * @param tree the tree where to search the nodes
+   * @param type the type to look for
+   * @returns an array with all nodes found
+   */
+  findByType,
+  /**
+   * Looks for a node with id `childId` and returns its parent. If no node is found, null is returned.
+   * 
+   * @param tree the tree where to search the node
+   * @param childId the id the child node to find
+   * @returns the parent node of `childId` or null if no node with id `childId` exists or if `childId`
+   * is the root node.
+   */
+  findParentByChildId,
+  /**
+   * Finds the position of the child with the given id in the array of children of a node. If no node
+   * is found, -1 is returned.
+   * 
+   * @param node the node where to look for the child
+   * @param childId the id of the child to look for
+   * @returns the position of the child in the array of children or -1 if such node doesn't exist.
+   */
+  indexOf,
 }

--- a/src/beagle-tree/iteration.ts
+++ b/src/beagle-tree/iteration.ts
@@ -19,16 +19,6 @@ import { BeagleUIElement } from './types'
 
 type Iteratee<ItemType, ReturnType> = (item: ItemType, index: number) => ReturnType
 
-/**
- * Uses a depth first search algorithm to traverse the tree. The iteratee function will be run for
- * each node (component). The iteratee function is triggered once a node is visited, i.e. the first
- * node to run the function is the root node and not the deepest left-most node.
- * 
- * The children of a node must be called "children" and be an array.
- * 
- * @param tree the tree to traverse
- * @param iteratee the function to call for each node of the tree
- */
 export function forEach<T extends BeagleUIElement>(tree: T, iteratee: Iteratee<T, void>): void {
   if (Object.keys(tree).length === 0) return
   let index = 0
@@ -41,21 +31,6 @@ export function forEach<T extends BeagleUIElement>(tree: T, iteratee: Iteratee<T
   run(tree)
 }
 
-/**
- * Does the same as forEach (depth-first-search), the difference is that the iteratee function
- * expects a return value, which will be used to replace the current node in the tree. A value must
- * be returned by the iteratee function, if you don't want to change the current node, just return
- * the same node you received. If a node is replaced by another one, the tree will be updated and
- * the next node to run the iteratee function will be the first child of the new node (if it has any
- * children).
- * 
- * The children of a node must be called "children" and be an array.
- * 
- * @param tree the tree to traverse
- * @param iteratee the function to call for each node of the tree. This function must return a node,
- * which will be used to replace the current node of the tree.
- * @returns the new tree
- */
 export function replaceEach<T extends BeagleUIElement>(
   tree: T,
   iteratee: Iteratee<T, T>,
@@ -76,15 +51,6 @@ export function replaceEach<T extends BeagleUIElement>(
   return run(tree)
 }
 
-/**
- * Uses a depth first search algorithm to traverse the tree and exposes this functionality as an
- * iterator. Each call to next() walks a step in the tree.
- * 
- * The children of a node must be called "children" and be an array.
- * 
- * @param tree the tree to traverse
- * @returns the iterator to iterate over the nodes
- */
 export function iterator(tree: BeagleUIElement): Iterator<BeagleUIElement> {
   if (Object.keys(tree).length === 0) return (function* () {})()
   

--- a/src/beagle-tree/manipulation.ts
+++ b/src/beagle-tree/manipulation.ts
@@ -18,17 +18,6 @@ import cloneDeep from 'lodash/cloneDeep'
 import { BeagleUIElement, IdentifiableBeagleUIElement, TreeInsertionMode } from './types'
 import { findById, findParentByChildId, indexOf } from './reading'
 
-/**
- * Adds a child element to the target tree. If the mode is "append", the child will be added as the
- * last element of the target's children. If "prepend", it will be added as the first child.
- * 
- * This function modifies `target`, it's not a pure function.
- * 
- * @param target the tree to be modified by receiving the new node `child`
- * @param child the node to insert into the tree `target`
- * @param mode the insertion strategy. Prepend (insert as first child), append (insert as last
- * child) or replace (removes all children and inserts `child`).
- */
 export function addChild<Schema>(
   target: BeagleUIElement<Schema>,
   child: BeagleUIElement<Schema>,
@@ -45,21 +34,6 @@ export function addChild<Schema>(
   modeHandlers[mode]()
 }
 
-/**
- * Combine two trees. This function inserts the tree `source` into the tree `target` at the node
- * referred by `anchor`. To tell which position `source` should occupy in the array of children of
- * `anchor`, you should use the last parameter `mode`.
- * 
- * If there's no node with id `anchor`, the tree will be left untouched.
- * 
- * This function modifies `target`, it's not a pure function.
- * 
- * @param target the tree to be modified by receiving the new branch `source`
- * @param source the tree to be inserted into `target`
- * @param anchor the id of the node to attach the new branch to
- * @param mode the insertion strategy. Prepend (insert as first child of `anchor`), append (insert
- * as last child of `anchor`) or replace (removes all children of `anchor` and inserts `child`).
- */
 export function insertIntoTree<Schema>(
   target: IdentifiableBeagleUIElement<Schema>,
   source: IdentifiableBeagleUIElement<Schema>,
@@ -71,21 +45,6 @@ export function insertIntoTree<Schema>(
   addChild(element, source, mode)
 }
 
-/**
- * Just like `insertIntoTree`, `replaceInTree` combines two trees. But, instead of inserting the
- * new branch as a child of the node referred by `anchor`, it completely replaces `anchor`, i.e.
- * after this function runs, `anchor` doesn't exist in `target` anymore, it gets replaced by the
- * tree `source`.
- * 
- * If there's no node with id `anchor` or if `anchor` is the root node, the tree will be left
- * untouched.
- * 
- * This function modifies `target`, it's not a pure function.
- * 
- * @param target the tree to be modified by receiving the new branch `source`
- * @param source the tree to be inserted into `target`
- * @param anchor the id of the node to be replaced by the new branch `source`
- */
 export function replaceInTree<Schema>(
   target: IdentifiableBeagleUIElement<Schema>,
   source: IdentifiableBeagleUIElement<Schema>,
@@ -97,12 +56,6 @@ export function replaceInTree<Schema>(
   parent.children!.splice(index, 1, source)
 }
 
-/**
- * Deep-clones the tree passed as parameter.
- * 
- * @param tree the tree to be cloned
- * @returns the clone of the tree
- */
 export function clone<T extends BeagleUIElement>(tree: T): T {
   return cloneDeep(tree)
 }

--- a/src/beagle-tree/reading.ts
+++ b/src/beagle-tree/reading.ts
@@ -16,13 +16,6 @@
 
 import { BeagleUIElement, IdentifiableBeagleUIElement } from './types'
 
-/**
- * Finds a node by its id. If no node is found, null is returned.
- * 
- * @param tree the tree where to search the node
- * @param id the id of the node to find
- * @returns the node with the given id or null if `tree` has no node with id `id`.
- */
 export function findById<Schema>(
   tree: IdentifiableBeagleUIElement<Schema>,
   id: string,
@@ -39,18 +32,6 @@ export function findById<Schema>(
   return component
 }
 
-/**
- * Finds every node in a tree where the value of `attributeName` is `attributeValue`. When
- * `attributeValue` is omitted, all nodes with a parameter called `attributeName` will be returned.
- * If no node is found, an empty array is returned.
- * 
- * @param tree the tree where to search the nodes
- * @param attributeName the attribute name to look for
- * @param attributeValue optional. The value of `attributeName` to look for. If not specified, any
- * value is accepted, i.e. a node, to be found, will only need to have a parameter `attributeName`,
- * no matter the value of it.
- * @returns an array with all nodes found
- */
 export function findByAttribute<T extends BeagleUIElement<any>>(
   tree: T,
   attributeName: string,
@@ -73,14 +54,6 @@ export function findByAttribute<T extends BeagleUIElement<any>>(
   return components
 }
 
-/**
- * Finds all nodes with a given type. The type of a node is defined by the property
- * `_beagleComponent_`. If no node is found, an empty array is returned.
- * 
- * @param tree the tree where to search the nodes
- * @param type the type to look for
- * @returns an array with all nodes found
- */
 export function findByType<T extends BeagleUIElement<any>>(
   tree: T,
   type: string,
@@ -88,14 +61,6 @@ export function findByType<T extends BeagleUIElement<any>>(
   return findByAttribute(tree, '_beagleComponent_', type)
 }
 
-/**
- * Looks for a node with id `childId` and returns its parent. If no node is found, null is returned.
- * 
- * @param tree the tree where to search the node
- * @param childId the id the child node to find
- * @returns the parent node of `childId` or null if no node with id `childId` exists or if `childId`
- * is the root node.
- */
 export function findParentByChildId<Schema>(
   tree: IdentifiableBeagleUIElement<Schema>,
   childId: string,
@@ -112,14 +77,6 @@ export function findParentByChildId<Schema>(
   return parent
 }
 
-/**
- * Finds the position of the child with the given id in the array of children of a node. If no node
- * is found, -1 is returned.
- * 
- * @param node the node where to look for the child
- * @param childId the id of the child to look for
- * @returns the position of the child in the array of children or -1 if such node doesn't exist.
- */
 export function indexOf(
   node: BeagleUIElement<any>,
   childId: string,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
closes #293 

The jsdocs could not be seen for any of the functions in the object `Tree` exported by the beagle-web-core. I fixed it, now the documentation can be seen by anyone who imports `Tree`. See the image below as an example:

![example image](https://i.ibb.co/W5xfGTx/Captura-de-Tela-2020-11-09-a-s-16-37-48.png)

**- How I did it**
To do it I had to transfer all the jsdocs to the index.ts file under `src/beagle-tree`. Unfortunately, Typescript loses all jsdocs when a function is re-exported. There's an [open issue about it in their repo](https://github.com/microsoft/TypeScript/issues/41216). 

I hope this gets fixed some day, but for now, placing the jsdocs in the final exportation is the only way I could find to fix it.

**- How to verify it**
Build beagle-web-core, link it to your project, import `Tree` and check if the documentation appears in the IDE.

**- Description for the changelog**
N/A
