### PR TITLE
Allows css transformation to be disabled

### DIFF
--- a/__tests__/unit/__snapshots__/index.spec.ts.snap
+++ b/__tests__/unit/__snapshots__/index.spec.ts.snap
@@ -19,6 +19,7 @@ Object {
     "assignId": [Function],
     "eraseNullProperties": [Function],
     "formatChildrenProperty": [Function],
+    "resetIdCounter": [Function],
   },
   "ObjectUtils": Object {
     "getOriginalKeyByCaseInsensitiveKey": [Function],

--- a/__tests__/unit/beagle-view/beagle-view.spec.ts
+++ b/__tests__/unit/beagle-view/beagle-view.spec.ts
@@ -18,6 +18,7 @@ import BeagleView from 'beagle-view'
 import { BeagleView as BeagleViewType, NetworkOptions } from 'beagle-view/types'
 import { NavigationController } from 'beagle-view/navigator/types'
 import { BeagleService, BeagleConfig } from 'service/beagle-service/types'
+import * as Renderer from 'beagle-view/render'
 import {
   createViewClientMock,
   createUrlBuilderMock,
@@ -39,6 +40,24 @@ describe('Beagle View', () => {
       const beagleService = createBeagleServiceMock()
       const beagleView = BeagleView.create(beagleService)
       expect(beagleView.getNetworkOptions()).toBeUndefined()
+    })
+
+    it('should disable css on renderer', () => {
+      const originalCreateRenderer = Renderer.default.create
+      Renderer.default.create = jest.fn()
+      const beagleService = createBeagleServiceMock({
+        getConfig: () => ({
+          baseUrl: '',
+          components: {},
+          platform: 'Test',
+          disableCssTransformation: true,
+        }),
+      })
+      BeagleView.create(beagleService)
+      expect(Renderer.default.create).toHaveBeenCalledWith(
+        expect.objectContaining({ disableCssTransformation: true }),
+      )
+      Renderer.default.create = originalCreateRenderer
     })
   })
 

--- a/__tests__/unit/beagle-view/render/integration.mock.ts
+++ b/__tests__/unit/beagle-view/render/integration.mock.ts
@@ -158,10 +158,20 @@ function createReadyToRenderElements() {
   return elements
 }
 
+function createElementsWithoutCss() {
+  const elements = createPreProcessedElements()
+
+  elements.buttonR1C1.onPress = expect.any(Function)
+  elements.number.text = 'result: 20'
+
+  return elements
+}
+
 export function createTree() {
   const original = createElements().root
   const preProcessed = createPreProcessedElements().root
   const readyToRender = createReadyToRenderElements().root
+  const withoutCss = createElementsWithoutCss().root
 
-  return { original, preProcessed, readyToRender }
+  return { original, preProcessed, readyToRender, withoutCss }
 }

--- a/__tests__/unit/beagle-view/render/integration.spec.ts
+++ b/__tests__/unit/beagle-view/render/integration.spec.ts
@@ -16,6 +16,7 @@
 
 import Tree from 'beagle-tree'
 import { ChildrenMetadata } from 'metadata/types'
+import Component from 'beagle-view/render/component'
 import { createRenderer } from './utils'
 import { createTree } from './integration.mock'
 import { createBeagleViewMock } from '../../old-structure/utils/test-utils'
@@ -34,7 +35,7 @@ import { createBeagleViewMock } from '../../old-structure/utils/test-utils'
  */
 
 describe('Beagle View: render: integration', () => {
-  const { original, preProcessed, readyToRender } = createTree()
+  const { original, preProcessed, readyToRender, withoutCss } = createTree()
   const setTree = jest.fn()
   const renderToScreen = jest.fn()
   const beagleView = createBeagleViewMock()
@@ -54,5 +55,18 @@ describe('Beagle View: render: integration', () => {
 
   it('should be ready to render', () => {
     expect(renderToScreen).toHaveBeenCalledWith(readyToRender)
+  })
+
+  it('should not convert style to css', () => {
+    Component.resetIdCounter()
+    const renderer = createRenderer({
+      setTree,
+      renderToScreen,
+      beagleView,
+      childrenMetadata,
+      disableCssTransformation: true,
+    })
+    renderer.doFullRender(Tree.clone(original))
+    expect(renderToScreen).toHaveBeenCalledWith(withoutCss)
   })
 })

--- a/__tests__/unit/beagle-view/render/utils.ts
+++ b/__tests__/unit/beagle-view/render/utils.ts
@@ -46,6 +46,7 @@ export function createRenderer(params: Partial<Parameters<typeof Renderer.create
     executionMode: params.executionMode || 'development',
     renderToScreen: params.renderToScreen || jest.fn(),
     typesMetadata: params.typesMetadata || {},
+    disableCssTransformation: params.disableCssTransformation || false,
   })
 
   return renderer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-web",
-  "version": "1.5.0",
+  "version": "1.6.0-alpha.1",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "Apache-2.0",

--- a/src/beagle-view/index.ts
+++ b/src/beagle-view/index.ts
@@ -216,6 +216,7 @@ function createBeagleView(
       renderToScreen: runListeners,
       setTree,
       typesMetadata: {},
+      disableCssTransformation: !!beagleService.getConfig().disableCssTransformation,
     })
   }
 

--- a/src/beagle-view/render/component.ts
+++ b/src/beagle-view/render/component.ts
@@ -63,6 +63,14 @@ function assignId(component: BeagleUIElement) {
 }
 
 /**
+ * Resets the id counter. Use with caution, by calling this function the ids won't be guaranteed
+ * to be unique anymore. Useful for creating test case scenarios.
+ */
+function resetIdCounter() {
+  nextId = 1
+}
+
+/**
  * Removes every property in `component` that has the value `null`. Ignores properties inside
  * `children`.
  * 
@@ -92,5 +100,6 @@ function eraseNullProperties(component: BeagleUIElement) {
 export default {
   formatChildrenProperty,
   assignId,
+  resetIdCounter,
   eraseNullProperties,
 }

--- a/src/beagle-view/render/index.ts
+++ b/src/beagle-view/render/index.ts
@@ -40,6 +40,7 @@ interface Params {
   executionMode: ExecutionMode,
   actionHandlers: Record<string, ActionHandler>,
   operationHandlers: Record<string, Operation>,
+  disableCssTransformation: boolean,
 }
 
 function createRenderer({
@@ -52,6 +53,7 @@ function createRenderer({
   executionMode,
   actionHandlers,
   operationHandlers,
+  disableCssTransformation,
 }: Params): Renderer {
   const { urlBuilder, preFetcher, globalContext } = beagleView.getBeagleService()
 
@@ -126,7 +128,7 @@ function createRenderer({
         beagleView,
       })
       const resolved = Expression.resolveForComponent(component, contextMap[component.id], operationHandlers)
-      Styling.convert(resolved)
+      if (!disableCssTransformation) Styling.convert(resolved)
 
       return resolved
     })

--- a/src/service/beagle-service/types.ts
+++ b/src/service/beagle-service/types.ts
@@ -152,6 +152,10 @@ export interface BeagleConfig<Schema> {
    * Note: If you create custom operations using the same name of a default from Beagle, the default will be overwritten by the custom one
    */
   customOperations?: Record<string, Operation>,
+  /**
+   * Disables the default style conversion to CSS in a Beagle tree.
+   */
+  disableCssTransformation?: boolean,
 }
 
 export type BeagleService = Readonly<{


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Allowed css transformation to be disabled. This is useful to support platforms like Flutter.

I also added the function `resetIdCounter` to the component renderer. This is useful for creating test scenarios where the id matters but we don't want to make it dependent on the previous tests in the same file.

The version of the project has been upgraded to 1.6.0-alpha.1, since I need it published to use it in Beagle Flutter.

**- How I did it**
New property in the config (default is not to disable css)

**- How to verify it**
Run tests or, when running Beagle, pass `disableCssTransformation: true` to the config. Everything will break if you don't tread the style yourself.

**- Description for the changelog**
- Implements option to disable CSS transformation
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
