### PR TITLE
fixes storage types

### DIFF
--- a/__tests__/unit/old-structure/tree-fetching/cache-ttl.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/cache-ttl.spec.ts
@@ -21,12 +21,13 @@ import RemoteCache, { beagleCacheNamespace } from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../mocks'
 import { createLocalStorageMock } from '../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const url = 'http://my-app/my-view'
 
 describe('Utils: tree fetching (cacheCheckingTTL)', () => {
   const httpClient = { fetch }
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
   Date.now = jest.fn(() => 20203030)
 

--- a/__tests__/unit/old-structure/tree-fetching/cache.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/cache.spec.ts
@@ -21,12 +21,13 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../mocks'
 import { createLocalStorageMock } from '../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const url = 'http://my-app/my-view'
 
 describe('Utils: tree fetching (cache)', () => {
   const httpClient = { fetch }
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
   const initialStorageValues = {
     [`${namespace}/${url}/get`]: JSON.stringify(treeA),

--- a/__tests__/unit/old-structure/tree-fetching/server.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/server.spec.ts
@@ -22,6 +22,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { createLocalStorageMock } from '../utils/test-utils'
 import { treeA } from '../mocks'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -29,7 +30,7 @@ const url = `${basePath}${path}`
 
 describe('Utils: tree fetching (server)', () => {
   const httpClient = { fetch }
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/beagle-cache-only.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/beagle-cache-only.spec.ts
@@ -24,6 +24,7 @@ import RemoteCache, { beagleCacheNamespace } from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -35,7 +36,7 @@ describe('Utils: tree fetching (load: beagle-cache-only)', () => {
   const cacheKey = `${beagleCacheNamespace}/${url}/get`
   const treeKey = `${namespace}/${url}/get`
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   Date.now = jest.fn(() => 20203030)

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/beagle-with-fallback-to-cache.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/beagle-with-fallback-to-cache.spec.ts
@@ -24,6 +24,7 @@ import RemoteCache, { beagleCacheNamespace } from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA, treeB } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -35,7 +36,7 @@ describe('Utils: tree fetching (load: beagle-with-fallback-to-cache)', () => {
   const cacheKey = `${beagleCacheNamespace}/${url}/get`
   const treeKey = `${namespace}/${url}/get`
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-first.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-first.spec.ts
@@ -23,6 +23,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA, treeB } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -32,7 +33,7 @@ describe('Utils: tree fetching (load: cache-first)', () => {
   const strategy: Strategy = 'cache-first'
   const httpClient = { fetch }
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-only.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-only.spec.ts
@@ -21,6 +21,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -30,7 +31,7 @@ describe('Utils: tree fetching (load: cache-only)', () => {
   const strategy: Strategy = 'cache-only'
   const httpClient = { fetch }
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-with-fallback-to-network.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/cache-with-fallback-to-network.spec.ts
@@ -23,6 +23,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'index'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -32,7 +33,7 @@ describe('Utils: tree fetching (load: cache-with-fallback-to-network)', () => {
   const strategy: Strategy = 'cache-with-fallback-to-network'
   const httpClient = { fetch }
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/network-only.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/network-only.spec.ts
@@ -22,6 +22,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -31,7 +32,7 @@ describe('Utils: tree fetching (load: network only)', () => {
   const strategy: Strategy = 'network-only'
   const httpClient = { fetch }
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/tree-fetching/stratetegies/network-with-fallback-to-cache.spec.ts
+++ b/__tests__/unit/old-structure/tree-fetching/stratetegies/network-with-fallback-to-cache.spec.ts
@@ -23,6 +23,7 @@ import RemoteCache from 'service/network/remote-cache'
 import DefaultHeaders from 'service/network/default-headers'
 import { treeA } from '../../mocks'
 import { createLocalStorageMock } from '../../utils/test-utils'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 const basePath = 'http://teste.com'
 const path = '/myview'
@@ -32,7 +33,7 @@ describe('Utils: tree fetching (load: network-with-fallback-to-cache)', () => {
   const strategy: Strategy = 'network-with-fallback-to-cache'
   const httpClient = { fetch }
   const retry = jest.fn()
-  let storage: Storage
+  let storage: BeagleStorage
   let viewClient: ViewClientType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/utils/cache-metadata.spec.ts
+++ b/__tests__/unit/old-structure/utils/cache-metadata.spec.ts
@@ -18,10 +18,11 @@ import nock from 'nock'
 import { createLocalStorageMock } from './test-utils'
 import RemoteCache, { beagleCacheNamespace } from 'service/network/remote-cache'
 import { RemoteCache as RemoteCacheType } from 'service/network/remote-cache/types'
+import { BeagleStorage } from 'service/beagle-service/types'
 
 describe.only('cache-metadata', () => {
   const url = 'http://test.com'
-  let storage: Storage
+  let storage: BeagleStorage
   let remoteCache: RemoteCacheType
 
   beforeEach(() => {

--- a/__tests__/unit/old-structure/utils/test-utils.ts
+++ b/__tests__/unit/old-structure/utils/test-utils.ts
@@ -18,7 +18,7 @@ import { BeagleUIElement } from 'beagle-tree/types'
 import { BeagleView } from 'beagle-view/types'
 import { Renderer } from 'beagle-view/render/types'
 import { BeagleNavigator } from 'beagle-view/navigator/types'
-import { BeagleService } from 'service/beagle-service/types'
+import { BeagleService, BeagleStorage } from 'service/beagle-service/types'
 import { GlobalContext } from 'service/global-context/types'
 import { DefaultHeaders } from 'service/network/default-headers/types'
 import { RemoteCache } from 'service/network/remote-cache/types'
@@ -28,7 +28,7 @@ import { PreFetcher } from 'service/network/pre-fetcher/types'
 import { HttpClient } from 'service/network/types'
 import defaultOperations from 'operation'
 
-export function createLocalStorageMock(storage: Record<string, string> = {}): Storage {
+export function createLocalStorageMock(storage: Record<string, string> = {}): BeagleStorage {
   return {
     getItem: jest.fn(key => storage[key] || null),
     setItem: jest.fn((key, value) => storage[key] = value),
@@ -36,8 +36,6 @@ export function createLocalStorageMock(storage: Record<string, string> = {}): St
       const keys = Object.keys(storage)
       keys.forEach(k => delete storage[k])
     }),
-    key: jest.fn(),
-    length: 0,
     removeItem: jest.fn(key => delete storage[key]),
   }
 }

--- a/__tests__/utils/function.ts
+++ b/__tests__/utils/function.ts
@@ -42,7 +42,7 @@ export function whenCalledTimes(
   const interval = 20
   let attempts = 0
 
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     const id = setInterval(() => {
       if (fn.mock.calls.length >= times) {
         clearInterval(id)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-web",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0-alpha.2",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "Apache-2.0",

--- a/src/service/beagle-service/types.ts
+++ b/src/service/beagle-service/types.ts
@@ -68,6 +68,22 @@ export interface Analytics {
   trackEventOnScreenDisappeared: (screenEvent: ScreenEvent) => void,
 }
 
+export interface SynchronousStorage {
+  getItem: (key: string) => string | null,
+  setItem: (key: string, value: string) => void,
+  clear: () => void,
+  removeItem: (key: string) => void,
+}
+
+export interface AsynchronousStorage {
+  getItem: (key: string) => Promise<string | null>,
+  setItem: (key: string, value: string) => Promise<void>,
+  clear: () => Promise<void>,
+  removeItem: (key: string) => Promise<void>,
+}
+
+export type BeagleStorage = SynchronousStorage | AsynchronousStorage
+
 export interface BeagleConfig<Schema> {
   /**
    * URL to the backend providing the views (JSON) for Beagle. 
@@ -124,7 +140,7 @@ export interface BeagleConfig<Schema> {
   /**
    * The custom storage. By default, uses the browser's `localStorage`.
    */
-  customStorage?: Storage,
+  customStorage?: BeagleStorage,
   /**
    * Wether or not to send specific beagle headers in the requests to fetch a view. Default is true.
    */
@@ -175,7 +191,7 @@ export type BeagleService = Readonly<{
   childrenMetadata: ChildrenMetadataMap,
   operationHandlers: Record<string, Operation>,
   // services
-  storage: Storage,
+  storage: BeagleStorage,
   httpClient: HttpClient,
   urlBuilder: URLBuilder,
   analytics?: Analytics,

--- a/src/service/network/remote-cache/index.ts
+++ b/src/service/network/remote-cache/index.ts
@@ -15,11 +15,12 @@
  */
 
 import { HttpMethod } from 'service/network/types'
+import { BeagleStorage } from 'service/beagle-service/types'
 import { RemoteCache, CacheMetadata } from './types'
 
 export const beagleCacheNamespace = '@beagle-web/beagle-cache'
 
-function createRemoteCache(storage: Storage): RemoteCache {
+function createRemoteCache(storage: BeagleStorage): RemoteCache {
   async function getMetadata(url: string, method: HttpMethod) {
     const cacheMetadataFromStorage = (
       await storage.getItem(`${beagleCacheNamespace}/${url}/${method}`)  

--- a/src/service/network/view-client/index.ts
+++ b/src/service/network/view-client/index.ts
@@ -22,6 +22,7 @@ import { BeagleUIElement, ErrorComponentParams } from 'beagle-tree/types'
 import { HttpClient, HttpMethod } from 'service/network/types'
 import { RemoteCache, CacheMetadata } from 'service/network/remote-cache/types'
 import { DefaultHeaders } from 'service/network/default-headers/types'
+import { BeagleStorage } from 'service/beagle-service/types'
 import { ViewClient, Strategy, StrategyType, StrategyArrays, ViewClientLoadParams } from './types'
 
 export const namespace = '@beagle-web/cache'
@@ -39,7 +40,7 @@ const strategyNameToStrategyArrays: Record<Strategy, StrategyArrays> = {
 }
 
 function createViewClient(
-  storage: Storage,
+  storage: BeagleStorage,
   defaultHeadersService: DefaultHeaders,
   remoteCache: RemoteCache,
   httpClient: HttpClient,
@@ -113,7 +114,7 @@ function createViewClient(
     let response: Response
     const requestTime = Date.now()
     const defaultHeaders = await defaultHeadersService.get(url, method)
-    const allHeaders = { ...headers, ...defaultHeaders }
+    const allHeaders: Record<string, any> = { ...headers, ...defaultHeaders }
     try {
       response = await httpClient.fetch(
         url,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
The type of storage was wrong. Although we always use only getItem, setItem, remove and clear, we used the Storage default type, which has much more methods that we don't use. At the same time, we always treat asynchronous operations when requesting stuff from the storage, but the typing didn't reflect it.

**- How I did it**
Created new type for storage and fixed all places that used the wrong type.

**- How to verify it**
Tests

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
