### PR TITLE
Fix: Corner Radius should support zero value (same rule as CSS)

### DIFF
--- a/__tests__/unit/old-structure/middlewares/beagleStyleMiddleware.spec.ts
+++ b/__tests__/unit/old-structure/middlewares/beagleStyleMiddleware.spec.ts
@@ -114,6 +114,12 @@ describe('StyleMiddleware', () => {
     expect(tree).toEqual(mocks.treeWithCornerRadiusParsed)
   })
 
+  it('should handle corner Radius with zero as value', () => {
+    const tree = Tree.clone(mocks.treeWithZeroCornerRadius)
+    Tree.forEach(tree, Styling.convert)
+    expect(tree).toEqual(mocks.treeWithZeroCornerRadiusParsed)
+  })
+
   it('should keep borderStyle value when border Style is present', () => {
     const tree = Tree.clone(mocks.treeWithBorderStyle)
     Tree.forEach(tree, Styling.convert)

--- a/__tests__/unit/old-structure/styles-mocks.ts
+++ b/__tests__/unit/old-structure/styles-mocks.ts
@@ -1237,6 +1237,26 @@ export const treeWithCornerRadiusParsed = {
   }
 }
 
+export const treeWithZeroCornerRadius = {
+  id: 'G.1',
+  _beagleComponent_: 'type-G',
+  style: {
+    backgroundColor: "#0f4c81",
+    cornerRadius: {
+      radius: 0
+    }
+  }
+}
+
+export const treeWithZeroCornerRadiusParsed = {
+  id: 'G.1',
+  _beagleComponent_: 'type-G',
+  style: {
+    backgroundColor: "#0f4c81",
+    borderRadius: '0px'
+  }
+}
+
 export const treeWithoutBorderStyle = {
   id: 'Border',
   _beagleComponent_: 'type-border',

--- a/src/beagle-view/render/styling.ts
+++ b/src/beagle-view/render/styling.ts
@@ -216,7 +216,7 @@ function formatFlexAttributes(flex: BeagleStyle['flex']) {
 }
 
 function formatCornerRadiusAttributes(cornerRadius: BeagleStyle['cornerRadius']): CSS {
-  return cornerRadius && typeof cornerRadius === 'object' && cornerRadius.radius
+  return cornerRadius && typeof cornerRadius === 'object' && Number.isFinite(cornerRadius.radius)
     ? { borderRadius: `${cornerRadius.radius}px` }
     : {}
 }


### PR DESCRIPTION
**- What I did**
Added a better validation for `cornerRadius`, because when was coming zero it was removing the property. 

**- How I did it**
Added a validation using `Number.isFinite(arg)`, which validates if a number is finite (as the name says), returning a boolean. The method works with any kind of object, so now it is 100% compatible with CSS rules.

**- How to verify it**
Create a POC with the framework that you want (Angular/React), link the dependencies with core, than create an structure styling your component with `cornerRadius: 0`, then test on your html, it should render with style like: `border-radius: 0px;`.

Example of structure:
```json
{
  "id": "myContainer",
  "_beagleComponent_": "beagle:container",
  "style": {
    "backgroundColor": "#0f4c81",
    "cornerRadius": {
      "radius": 0
    }
  }
}
```

The Style Properties should contain:
```json
{
    "background-color": "#0f4c81",
    "border-radius": "10px"
}
```

**- Description for the changelog**
During a Foundation Meeting we were inspecting other features and then we bring up a discussion about attributes and how it works on each platform, so I identified that this validation was missing, only values higher than zero were being parsed.
