### PR TITLE
Fix: doTemplateRender always appending

### DIFF
--- a/__tests__/unit/beagle-view/render/template.spec.ts
+++ b/__tests__/unit/beagle-view/render/template.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import nock from 'nock'
 import BeagleService from 'service/beagle-service'
 import { BeagleView } from 'beagle-view/types'
 import { mockLocalStorage } from '../../old-structure/utils/test-utils'
@@ -28,7 +27,7 @@ describe('Render a template with doTemplateRender ', () => {
   const viewId = 'beagleId'
   const mocks = createTemplateRenderMocks()
   const localStorageMock = mockLocalStorage()
-  const { createView,viewContentManagerMap } = BeagleService.create({
+  const { createView, viewContentManagerMap } = BeagleService.create({
     baseUrl,
     components: {},
   })
@@ -39,7 +38,6 @@ describe('Render a template with doTemplateRender ', () => {
       view = createView()
       view.getRenderer().doFullRender(mocks.baseContainer as BeagleUIElement)
       viewContentManagerMap.register(viewId, view)
-      nock.cleanAll()
       localStorageMock.clear()
     })
 
@@ -59,6 +57,14 @@ describe('Render a template with doTemplateRender ', () => {
       const componentManager = jest.fn((component: IdentifiableBeagleUIElement, index: number) => {
         return component
       })
+
+      const templateOrder = [
+        mocks.templateManager.templates[0].view,
+        mocks.templateManager.templates[1].view,
+        mocks.templateManager.default,
+        mocks.templateManager.templates[2].view,
+        mocks.templateManager.templates[3].view,
+      ]
 
       beforeAll(() => {
         view.getRenderer().doTemplateRender(mocks.templateManager, 'template-container', mocks.dataSource, componentManager)
@@ -88,11 +94,9 @@ describe('Render a template with doTemplateRender ', () => {
 
       it('should have been called the componentManager five times with the respective template', async () => {
         expect(componentManager).toHaveBeenCalledTimes(5)
-        expect(componentManager).toHaveBeenNthCalledWith(1, mocks.templateManager.templates[0].view, 0)
-        expect(componentManager).toHaveBeenNthCalledWith(2, mocks.templateManager.templates[1].view, 1)
-        expect(componentManager).toHaveBeenNthCalledWith(3, mocks.templateManager.default, 2)
-        expect(componentManager).toHaveBeenNthCalledWith(4, mocks.templateManager.templates[2].view, 3)
-        expect(componentManager).toHaveBeenNthCalledWith(5, mocks.templateManager.templates[3].view, 4)
+        for (let i = 0; i < 5; i++) {
+          expect(componentManager).toHaveBeenNthCalledWith(i + 1, templateOrder[i], i)
+        }
       })
 
       it('should render the first template on the first position', async () => {
@@ -123,6 +127,58 @@ describe('Render a template with doTemplateRender ', () => {
       it('should render the full tree matching the cases of templates', async () => {
         expect(tree).toEqual(mocks.renderedContainer)
       })
+
+      describe('Insertion Modes', () => {
+        beforeAll(() => {
+          componentManager.mockClear()
+        })
+
+        it('should have five children', async () => {
+          expect(view.getTree().children).toBeDefined()
+          expect(view.getTree().children?.length).toBe(5)
+        })
+
+        it('should continue with five children after a new template render call, without the mode being defined', () => {
+          view.getRenderer().doTemplateRender(mocks.templateManager, 'template-container', mocks.dataSource, componentManager)
+          expect(view.getTree().children).toBeDefined()
+          expect(view.getTree().children?.length).toBe(5)
+        })
+
+        it('should have ten children when the mode is defined as "append", having the previous result and then appended the new result', () => {
+          view.getRenderer().doTemplateRender(mocks.templateManager, 'template-container', mocks.dataSource, componentManager, 'append')
+          const renderedChildren = view.getTree().children || []
+
+          expect(renderedChildren).toBeDefined()
+          expect(renderedChildren.length).toBe(10)
+          expect(componentManager).toHaveBeenCalledTimes(10)
+
+          for (let i = 0; i < 10; i++) {
+            const relativeIndex = (i >= 5 ? (i - 5) : i)
+            expect(componentManager).toHaveBeenNthCalledWith(i + 1, templateOrder[relativeIndex], relativeIndex)
+            expect(renderedChildren[i].id).toEqual(templateOrder[relativeIndex]?.id)
+            expect(renderedChildren[i]).toEqual(mockChildren[relativeIndex])
+          }
+        })
+
+        it('should have fifteen children when the mode is defined as "prepend", having the new result and then appended the previous result', () => {
+          view.getRenderer().doTemplateRender(mocks.templateManager, 'template-container', mocks.dataSource, componentManager, 'prepend')
+          const renderedChildren = view.getTree().children || []
+
+          expect(renderedChildren).toBeDefined()
+          expect(renderedChildren.length).toBe(15)
+          expect(componentManager).toHaveBeenCalledTimes(15)
+
+          for (let i = 0; i < 15; i++) {
+            const subtract = [15, 10, 5].find(tol => i >= tol) || 0
+            const relativeIndex = (i >= subtract ? (i - subtract) : i)
+            const relativeReversedIndex = (i < 5 ? ((5 - 1) - i) : relativeIndex)
+
+            expect(componentManager).toHaveBeenNthCalledWith(i + 1, templateOrder[relativeIndex], relativeIndex)
+            expect(renderedChildren[i].id).toEqual(templateOrder[relativeReversedIndex]?.id)
+            expect(renderedChildren[i]).toEqual(mockChildren[relativeReversedIndex])
+          }
+        })
+      })
     })
   })
 
@@ -132,7 +188,6 @@ describe('Render a template with doTemplateRender ', () => {
       view = createView()
       view.getRenderer().doFullRender(mocks.baseContainer as BeagleUIElement)
       viewContentManagerMap.register(viewId, view)
-      nock.cleanAll()
       localStorageMock.clear()
     })
 
@@ -190,12 +245,20 @@ describe('Render a template with doTemplateRender ', () => {
         const views = mocks.exceptionTemplateManager.templates.map(t => t.view)
 
         expect(componentManager).toHaveBeenCalledTimes(6)
-        expect(componentManager).toHaveBeenNthCalledWith(1, { ...views[0], id: `${views[0].id}:${1}`}, 1)
-        expect(componentManager).toHaveBeenNthCalledWith(2, { ...views[0], id: `${views[0].id}:${2}`}, 2)
-        expect(componentManager).toHaveBeenNthCalledWith(3, { ...views[2], id: `${views[2].id}:${3}`}, 3)
-        expect(componentManager).toHaveBeenNthCalledWith(4, { ...views[3], id: `${views[3].id}:${5}`}, 5)
-        expect(componentManager).toHaveBeenNthCalledWith(5, { ...views[1], id: `${views[1].id}:${7}`}, 7)
-        expect(componentManager).toHaveBeenNthCalledWith(6, { ...views[2], id: `${views[2].id}:${8}`}, 8)
+
+        const order = [
+          { viewIndex: 0, elementIndex: 1 },
+          { viewIndex: 0, elementIndex: 2 },
+          { viewIndex: 2, elementIndex: 3 },
+          { viewIndex: 3, elementIndex: 5 },
+          { viewIndex: 1, elementIndex: 7 },
+          { viewIndex: 2, elementIndex: 8 },
+        ]
+
+        for (let i = 0; i < order.length; i++) {
+          const item = order[i]
+          expect(componentManager).toHaveBeenNthCalledWith(i + 1, { ...views[item.viewIndex], id: `${views[item.viewIndex].id}:${item.elementIndex}` }, item.elementIndex)
+        }
       })
 
       it('should not render a context when the case is not matched and default template is not defined', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-web",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "Apache-2.0",

--- a/src/beagle-view/render/types.ts
+++ b/src/beagle-view/render/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BeagleUIElement, DataContext, IdentifiableBeagleUIElement, TreeUpdateMode } from 'beagle-tree/types'
+import { BeagleUIElement, DataContext, IdentifiableBeagleUIElement, TreeInsertionMode, TreeUpdateMode } from 'beagle-tree/types'
 import { ComponentManager, TemplateManager } from 'beagle-view/render/template-manager/types'
 
 export interface Renderer {
@@ -59,48 +59,51 @@ export interface Renderer {
     mode?: TreeUpdateMode,
   ) => void,
 
-/**
- * Renders according to a template manager and a matrix of contexts.
- *
- * Each line in the matrix of contexts represents an iteration and each column represents the value
- * of a template variable. For instance, imagine a template with the variables `@{name}`, `@{sex}`
- * and `@{address}`. Now suppose we want to render three different entries with this template.
- * Here's a context matrix that could be used for this example:
- *
- * [
- *   [{ id: 'name', value: 'John' }, { id: 'sex', value: 'M' }, { id: 'address', value: { street: '42 Avenue', number: '256' } }],
- *   [{ id: 'name', value: 'Sue' }, { id: 'sex', value: 'F' }, { id: 'address', value: { street: 'St Monica St', number: '85' } }],
- *   [{ id: 'name', value: 'Paul' }, { id: 'sex', value: 'M' }, { id: 'address', value: { street: 'Bv Kennedy', number: '877' } }],
- * ]
- *
- * Note that the parameter `contexts` adds to the context hierarchy that is already present in the
- * tree, it doesn't replace it, i.e. you can still use the contexts declared in the current tree.
- *
- * For each line of the context matrix, a template is chosen from the template manager according to
- * `case`, which is a boolean or a beagle expression that resolves to a boolean. When `case` is an
- * expression, it's resolved using the entire context of the current tree plus the contexts passed
- * in the parameter `contexts` corresponding to the current iteration. If no template attends the
- * condition the default template is used. If there's no default template, the iteration is skipped.
- *
- * After processing all items, the resulting tree is attached to the current tree at the node with
- * id `anchor` (passed as parameter).
- *
- * The component manager is an optional parameter and is used to modify the resulting component.
- * This can be very useful for managing ids, for instance. The component manager is a function that
- * receives the component generated and the index of the current iteration, returning the modified
- * component.
- *
- * @param templateManager templates used to render each line of the context matrix.
- * @param anchor the id of the node in the current tree to attach the new nodes to.
- * @param contexts matrix of contexts where each line represents an item to be rendered according to
- * the templateManager.
- * @param componentManager optional. When set, the component goes through this function before being
- * finally rendered.
- */
+  /**
+   * Renders according to a template manager and a matrix of contexts.
+   *
+   * Each line in the matrix of contexts represents an iteration and each column represents the value
+   * of a template variable. For instance, imagine a template with the variables `@{name}`, `@{sex}`
+   * and `@{address}`. Now suppose we want to render three different entries with this template.
+   * Here's a context matrix that could be used for this example:
+   *
+   * [
+   *   [{ id: 'name', value: 'John' }, { id: 'sex', value: 'M' }, { id: 'address', value: { street: '42 Avenue', number: '256' } }],
+   *   [{ id: 'name', value: 'Sue' }, { id: 'sex', value: 'F' }, { id: 'address', value: { street: 'St Monica St', number: '85' } }],
+   *   [{ id: 'name', value: 'Paul' }, { id: 'sex', value: 'M' }, { id: 'address', value: { street: 'Bv Kennedy', number: '877' } }],
+   * ]
+   *
+   * Note that the parameter `contexts` adds to the context hierarchy that is already present in the
+   * tree, it doesn't replace it, i.e. you can still use the contexts declared in the current tree.
+   *
+   * For each line of the context matrix, a template is chosen from the template manager according to
+   * `case`, which is a boolean or a beagle expression that resolves to a boolean. When `case` is an
+   * expression, it's resolved using the entire context of the current tree plus the contexts passed
+   * in the parameter `contexts` corresponding to the current iteration. If no template attends the
+   * condition the default template is used. If there's no default template, the iteration is skipped.
+   *
+   * After processing all items, the resulting tree is attached to the current tree at the node with
+   * id `anchor` (passed as parameter).
+   *
+   * The component manager is an optional parameter and is used to modify the resulting component.
+   * This can be very useful for managing ids, for instance. The component manager is a function that
+   * receives the component generated and the index of the current iteration, returning the modified
+   * component.
+   *
+   * @param templateManager templates used to render each line of the context matrix.
+   * @param anchor the id of the node in the current tree to attach the new nodes to.
+   * @param contexts matrix of contexts where each line represents an item to be rendered according to
+   * the templateManager.
+   * @param componentManager optional. When set, the component goes through this function before being
+   * finally rendered.
+   * @param mode optional. when `viewTree` is just a new branch to be added to the tree, the mode must be
+   * specified. It can be `append`, `prepend` or `replace`. The default value is `replace`
+  */
   doTemplateRender: (
     templateManager: TemplateManager,
     anchor: string,
     contexts: DataContext[][],
     componentManager?: ComponentManager,
+    mode?: TreeInsertionMode
   ) => void,
 }


### PR DESCRIPTION
**- What I did**
Created a new parameter, on `doTemplateRender`, named `mode: TreeInsertionMode`, where the user can set the mode that children will be added to the anchor element on the tree.

**Warning**
It also patches the current version of `beagle-web` because it may break some features using `ListView` or `GridView`