### PR TITLE
Fix: Null tree and same set context for globalContext as regular contexts

### DIFF
--- a/src/beagle-view/index.ts
+++ b/src/beagle-view/index.ts
@@ -146,7 +146,7 @@ const createBeagleView: CreateBeagleView = (
       setTree(originalTree) // changes should be made based on the original tree
       renderer.doFullRender(loadedTree, elementId, mode)
     }
-    
+
     try {
       await beagleService.viewClient.load({
         url,
@@ -254,6 +254,7 @@ const createBeagleView: CreateBeagleView = (
       disableCssTransformation: !!beagleService.getConfig().disableCssTransformation,
     })
   }
+
   function setupNavigation() {
     navigator.subscribe(async (route, navigationController) => {
       const { urlBuilder, preFetcher, analyticsService } = beagleService

--- a/src/beagle-view/render/index.ts
+++ b/src/beagle-view/render/index.ts
@@ -60,7 +60,7 @@ function createRenderer({
 }: Params): Renderer {
   const { urlBuilder, preFetcher, globalContext } = beagleView.getBeagleService()
 
-  function runGlobalLifecycleHook(viewTree: any, lifecycle: Lifecycle) {
+  function runGlobalLifecycleHook(viewTree: any = {}, lifecycle: Lifecycle) {
     if (Object.keys(viewTree).length === 0) return viewTree
     const hook = lifecycleHooks[lifecycle].global
     if (!hook) return viewTree
@@ -107,7 +107,9 @@ function createRenderer({
     mode: TreeUpdateMode,
   ) {
     let currentTree = beagleView.getTree()
+
     if (!currentTree) return setTree(viewTree)
+
     anchor = anchor || currentTree.id
 
     if (mode === 'replaceComponent') {

--- a/src/service/global-context/index.ts
+++ b/src/service/global-context/index.ts
@@ -59,8 +59,9 @@ function createGlobalContext(): GlobalContext {
       globalContext.value = value
     else {
       globalContext.value = globalContext.value || {}
-      setLodash(globalContext.value, path, value)
+      setLodash(globalContext, `value.${path}`, value)
     }
+
     callUpdateListeners()
   }
 


### PR DESCRIPTION
**- What I did**
There was a scenario where the `uiTree` was not defined and the core could not handle it (specifically on the new React version), so I just added a default value for this `uiTree` and used the same strategy to set the context as used by the regular contexts, because it was an issue in the past and was fixed for regular contexts and nothing was done for `globalContext`