### PR TITLE
Feature/analytics root

### DIFF
--- a/src/beagle-view/index.ts
+++ b/src/beagle-view/index.ts
@@ -283,7 +283,7 @@ const createBeagleView: CreateBeagleView = (
       analyticsService.createScreenRecord({
         route: route,
         currentTree: getTree(),
-        platform: platform
+        platform: platform,
       })
 
     })

--- a/src/beagle-view/index.ts
+++ b/src/beagle-view/index.ts
@@ -277,11 +277,15 @@ const createBeagleView: CreateBeagleView = (
         const httpData = httpAdditionalData || networkOptions
         await fetch({ path: url, fallback, ...httpData, ...navigationController })
       }
+
       const platform = beagleService.getConfig().platform
+
       analyticsService.createScreenRecord({
         route: route,
-        platform: platform,
+        currentTree: getTree(),
+        platform: platform
       })
+
     })
   }
 

--- a/src/service/analytics/index.ts
+++ b/src/service/analytics/index.ts
@@ -14,31 +14,37 @@
  * limitations under the License.
  */
 
+import { BeagleView } from 'index'
 import formatActionRecord from './actions'
-import { AnalyticsProvider, AnalyticsRecord, ActionRecordParams, ScreenRecordParams } from './types'
+import { AnalyticsProvider, AnalyticsRecord, ActionRecordParams, ScreenRecordParams, ScreenAnalyticsRecord } from './types'
 
 function createAnalyticsService(provider?: AnalyticsProvider) {
 
   async function createScreenRecord(params: ScreenRecordParams) {
     if (!provider) return
     const config = provider.getConfig()
-    const { platform, route } = params
+    const { platform, route, currentTree } = params
 
     if (config && !config.enableScreenAnalytics) return
-    const record: AnalyticsRecord = {
+    const record: ScreenAnalyticsRecord = {
       type: 'screen',
       platform: `WEB ${platform}`,
-      timestamp: Date.now(),
+      timestamp: Date.now()
     }
 
     if (route) {
+
       if ('screen' in route)
         record.screen = route.screen.identifier || route.screen.id
 
       if ('url' in route)
         record.screen = route.url
-    }
 
+      /* The backend allows us to create the root component as a ScreenComponent, 
+      which means sometimes the root id might be an identifier
+      this is deprecated and will be removed in version 2.0 */
+      record.rootId = currentTree.identifier || currentTree.id
+    }
 
     provider.createRecord(record)
 

--- a/src/service/analytics/types.ts
+++ b/src/service/analytics/types.ts
@@ -43,6 +43,10 @@ export interface AnalyticsRecord {
   screen?: string,
 }
 
+export interface ScreenAnalyticsRecord extends AnalyticsRecord{
+  rootId?: string
+}
+
 export interface ActionAnalyticsRecord extends AnalyticsRecord {
   event: string,
   component: {
@@ -90,6 +94,7 @@ export interface ActionAnalyticsConfig {
 
 export interface ScreenRecordParams {
   route: Route,
+  currentTree: IdentifiableBeagleUIElement
   platform?: string,
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-core/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
 - Changed the screen record interface to accept a new property ``rootId``
 - This property should be logged when screen events happen
 
**- How I did it**
 - Used the utilitary ``Tree`` to get the id of the current view. If the current tree contains a Screen Component as root component it searches fot the ``identifier`` otherwise it looks for the ``Id``
 
**- How to verify it**
 - Using the analytics 2.0 with screen tracking enabled.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
