### PR TITLE
fix: tree foreach

### DIFF
--- a/src/beagle-tree/iteration.ts
+++ b/src/beagle-tree/iteration.ts
@@ -25,7 +25,8 @@ export function forEach<T extends BeagleUIElement>(tree: T, iteratee: Iteratee<T
 
   function run(node: T) {
     iteratee(node, index++)
-    if (node.children) node.children.forEach(child => run(child as T))
+    const children = (node.children || (node.child ? [node.child] : null))
+    if (children) children.forEach(child => run(child as T))
   }
 
   run(tree)
@@ -53,7 +54,7 @@ export function replaceEach<T extends BeagleUIElement>(
 
 export function iterator(tree: BeagleUIElement): Iterator<BeagleUIElement> {
   if (Object.keys(tree).length === 0) return (function* () {})()
-  
+
   function* generator(node: BeagleUIElement): Iterator<BeagleUIElement> {
     yield node
     if (!node.children) return


### PR DESCRIPTION
Signed-off-by: Arthur Bleil <arthur.bleil@zup.com.br>

**- What I did**
Add support to the `child` property on the `forEach` Tree iteration method.

**- How I did it**
As described on the documentation, BeagleNode support `children` and `child` as the children property, but the iterator method only supported the `children` one, so I added to the properties to check the `child` property.

**- How to verify it**
Create a page with a component that has children and other one with child and then run the iterator method `Tree.forEach` on each wrapper.

**- Description for the changelog**
Tree: `forEach` iterator method now supports `child` property.